### PR TITLE
don't print "No config file found..." message

### DIFF
--- a/pinentry-dmenu.c
+++ b/pinentry-dmenu.c
@@ -784,8 +784,6 @@ main(int argc, char *argv[]) {
 		fprintf(stderr, "%s:%d: %s\n", config_error_file(&cfg),
 		        config_error_line(&cfg), config_error_text(&cfg));
 		return(EXIT_FAILURE);
-	} else {
-		printf("No config file found. Use defaults.\n");
 	}
 
 	pinentry_init("pinentry-dmenu");


### PR DESCRIPTION
On systems where musl is used as the libc, printf on pipe causes
libc to check whether the output is a terminal (by calling ioctl
TIOCGWINSZ) which results in broken pipe when an "OK" message is
written. Creating an empty config file was the workaround, but
it probably makes more sense to just disable the message altogether,
as it's not supposed to be seen by the user regardless.

	openat(AT_FDCWD, "/home/ftrvx/.gnupg/pinentry-dmenu.conf", O_RDONLY|O_LARGEFILE) = -1 ENOENT (No such file or directory)
	ioctl(1, TIOCGWINSZ, 0x7ff2ba8a98)      = -1 ENOTTY (Not a tty)
	writev(1, [{iov_base="", iov_len=0}, {iov_base="No config file found. Use defaul"..., iov_len=36}], 2) = 36
	brk(NULL)                               = 0x558549b000
	brk(0x55854a0000)                       = 0x55854a0000
	getuid()                                = 1000
	mlock(0x558549b020, 16384)              = 0
	geteuid()                               = 1000
	getuid()                                = 1000
	geteuid()                               = 1000
	getuid()                                = 1000
	geteuid()                               = 1000
	dup(0)                                  = 3
	dup(1)                                  = 4
	write(4, "OK Pleased to meet you, process "..., 37) = -1 EPIPE (Broken pipe)
	--- SIGPIPE {si_signo=SIGPIPE, si_code=SI_USER, si_pid=25113, si_uid=1000} ---