### PR TITLE
Add lineheight support

### DIFF
--- a/config.h
+++ b/config.h
@@ -5,6 +5,8 @@ static int bottom = 0;
 static int embedded = 0;
 static int minpwlen = 32;
 static int mon = -1;
+static int lineheight = 0;
+static int min_lineheight = 8;
 
 static const char *asterisk = "*";
 static const char *fonts[] = {

--- a/pinentry-dmenu.1
+++ b/pinentry-dmenu.1
@@ -37,6 +37,9 @@ pinentry-dmenu appears at the bottom of the screen.
 .BI "min_password_length =" " 32"
 The minimal space of the password field. This value has affect to the description field after the password field.
 .TP
+.BI "height =" " 8"
+Height of pinentry-dmenu in pixels (no less than 8)
+.TP
 .BI "monitor =" " -1"
 pinentry-dmenu is displayed on the monitor number supplied. Monitor numbers are starting from 0.
 .TP

--- a/pinentry-dmenu.c
+++ b/pinentry-dmenu.c
@@ -183,7 +183,7 @@ insert(const char *str, ssize_t n) {
 static void
 drawwin(void) {
 	unsigned int curpos;
-	int x = 0, pb, pbw = 0, i;
+	int x = 0, fh = drw->fonts->h, pb, pbw = 0, i;
 	size_t asterlen = strlen(asterisk);
 	size_t pdesclen;
 	int leftinput;
@@ -255,7 +255,7 @@ drawwin(void) {
 
 		if ((curpos += lrpad / 2 - 1) < leftinput) {
 			drw_setscheme(drw, scheme[SchemeNormal]);
-			drw_rect(drw, x + curpos, 2, 2, bh - 4, 1, 0);
+			drw_rect(drw, x + curpos, 2 + (bh - fh) / 2, 2, fh - 4, 1, 0);
 		}
 
 		free(censort);
@@ -293,6 +293,7 @@ setup(void) {
 
 	/* Calculate menu geometry */
 	bh = drw->fonts->h + 2;
+	bh = MAX(bh, lineheight);
 	mh = bh;
 #ifdef XINERAMA
 	info = XineramaQueryScreens(dpy, &n);
@@ -743,6 +744,9 @@ main(int argc, char *argv[]) {
 		}
 		if (config_lookup_int(&cfg, "min_password_length", &val)) {
 			minpwlen = val;
+		}
+		if (config_lookup_int(&cfg, "height", &val)) {
+			lineheight = MAX(val, min_lineheight);
 		}
 		if (config_lookup_int(&cfg, "monitor", &val)) {
 			mon = val;


### PR DESCRIPTION
Thanks for this little pinentry implementation!

One feature that I'm missing is line height, so pinentry-dmenu can match my regular dmenu config to cover polybar of specific height.

This is mostly [line height patch](https://tools.suckless.org/dmenu/patches/line-height/) transplant.